### PR TITLE
Set GPG_TTY

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -303,7 +303,7 @@ backup_this_script()
   then
     cp $CONFIG ${TMPDIR}/
   fi
-
+  export GPG_TTY=`tty`
   gpg -a --export-secret-keys ${GPG_KEY} > ${TMPDIR}/duplicity-backup-secret.key.txt
   echo -e ${README_TXT} > ${README}
   echo "Encrypting tarball, choose a password you'll remember..."


### PR DESCRIPTION
The script should set the GPG_TTY to prevent errors with the gpg-agent
