### PR TITLE
added mail option for centos 55

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -160,6 +160,7 @@ EMAIL_SUBJECT=
 
 # command to use to send mail
 MAIL="mailx"
+#MAIL="mail"
 #MAIL="ssmtp"
 
 # TROUBLESHOOTING: If you are having any problems running this script it is

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -241,7 +241,9 @@ email_logfile()
           elif [ "$MAIL" = "mailx" ]; then
             EMAIL_FROM=${EMAIL_FROM:+"-r ${EMAIL_FROM}"}
             cat ${LOGFILE} | ${MAILCMD} -s """${EMAIL_SUBJECT}""" $EMAIL_FROM ${EMAIL_TO}
-          fi
+	  elif [ "$MAIL" = "mail" ]; then
+	    cat ${LOGFILE} | ${MAILCMD} -s """${EMAIL_SUBJECT}""" $EMAIL_FROM ${EMAIL_TO} -- -f ${EMAIL_FROM}
+	  fi
           echo -e "Email alert sent to ${EMAIL_TO} using ${MAIL}" >> ${LOGFILE}
       fi
   fi


### PR DESCRIPTION
Here's a pull to subvert my 'patch' I created for issue 21.

On Centos 5.5 i686, even with the mailx package installed from yum, the script still won't send via mailx (which isn't in the PATH, or even an installed file (?)) I'm not a big Centos user, so I fixed the script so that it will also send with the stock mail command, this requires two changes.
