### PR TITLE
Let s3cmd have the correct bucket name when using s3 scheme

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -90,8 +90,12 @@ ROOT="/home"
 # for you).  If you don't want to use Amazon S3, you can backup
 # to a file or any of duplicity's supported outputs.
 #
-# NOTE: You do need to keep the "s3+http://<your location>/" format
-# even though duplicity supports "s3://<your location>/".
+# The s3+http scheme uses the default aws s3 hostname.
+# Use s3://host/bucket/[backup-folder/] if you want to specify the host name.
+# If using the s3://... scheme and you have s3cmd installed, be sure to change
+# 's3.amazonaws.com' to the appropriate host in your .s3cfg file so that the
+# remote file size check will work.
+#DEST="s3://host/backup-bucket/backup-folder/"
 DEST="s3+http://backup-bucket/backup-folder/"
 # Other possible locations
 #DEST="ftp://user[:password]@other.host[:port]/some_dir"

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -331,6 +331,11 @@ get_remote_file_size()
     "s3")
       if $S3CMD_AVAIL ; then
           TMPDEST=$(echo ${DEST} | cut -c 11-)
+          dest_scheme=$(echo ${DEST} | cut -f -1 -d :)
+          if [ "$dest_scheme" = "s3" ]; then
+              # Strip off the host name, too.
+              TMPDEST=`echo $TMPDEST | cut -f 2- -d /`
+          fi
           SIZE=`${S3CMD} du -H s3://${TMPDEST} | awk '{print $1}'`
       else
           SIZE="s3cmd not installed."


### PR DESCRIPTION
I was trying out an s3-compatible service, and needed to give their hostname instead of using the default aws s3 hostname.  So I set DEST to s3://host/bucket/ .  This worked fine for backup and restore.  The only part that had a problem was the part that gets the remote backup size.  This commit makes that work when using the s3:// scheme.
