### PR TITLE
Added the option to skip cleanup

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -192,7 +192,7 @@ STATIC_OPTIONS="--full-if-older-than 14D --s3-use-new-style"
 # backups leave room for problems in the chain, so doing a "full"
 # backup every so often is not a bad idea.
 #
-# You can either remove older than a specific time period:
+# You can remove older than a specific time period:
 #CLEAN_UP_TYPE="remove-older-than"
 #CLEAN_UP_VARIABLE="31D"
 #
@@ -200,6 +200,9 @@ STATIC_OPTIONS="--full-if-older-than 14D --s3-use-new-style"
 # than removing the files based on their age), you can use what I use:
 CLEAN_UP_TYPE="remove-all-but-n-full"
 CLEAN_UP_VARIABLE="4"
+
+# The third option is to skip cleanup altogether, by:
+# CLEAN_UP_TYPE="none"
 #
 # In combination with "remove-older-than" clean-up type, you may want
 # to keep only the full backups older than (n) number backup sets. For example, 

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -425,11 +425,13 @@ include_exclude()
 
 duplicity_cleanup()
 {
-  echo "-----------[ Duplicity Cleanup ]-----------" >> ${LOGFILE}
-  eval ${ECHO} ${DUPLICITY} ${CLEAN_UP_TYPE} ${CLEAN_UP_VARIABLE} ${STATIC_OPTIONS} --force \
-      ${ENCRYPT} \
-      ${DEST} >> ${LOGFILE}
-  echo >> ${LOGFILE}
+	echo "-----------[ Duplicity Cleanup ]-----------" >> ${LOGFILE}
+	if [[ "${CLEAN_UP_TYPE}" != "none" ]]; then
+	  eval ${ECHO} ${DUPLICITY} ${CLEAN_UP_TYPE} ${CLEAN_UP_VARIABLE} ${STATIC_OPTIONS} --force \
+		    ${ENCRYPT} \
+			  ${DEST} >> ${LOGFILE}
+	  echo >> ${LOGFILE}
+	fi
   if [ ! -z ${REMOVE_INCREMENTALS_OLDER_THAN} ] && [[ ${REMOVE_INCREMENTALS_OLDER_THAN} =~ ^[0-9]+$ ]]; then
     eval ${ECHO} ${DUPLICITY} remove-all-inc-of-but-n-full ${REMOVE_INCREMENTALS_OLDER_THAN} \
       ${STATIC_OPTIONS} --force \


### PR DESCRIPTION
I've added the option to skip cleanup by setting CLEANUP_TYPE to  'none'.
This is relevant to me because my s3 api key is not allowed to delete files,
making my backup more resistable to human error / someone getting hold of this
plaintext accessible key.
