### PR TITLE
duplicity-backup.sh: Fix quotation issue

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -417,7 +417,7 @@ include_exclude()
   done
   
   # Include/Exclude globbing filelist
-  if [ $INCEXCFILE != '' ]; then
+  if [ "$INCEXCFILE" != '' ]; then
     TMP=" --include-globbing-filelist ""'"$INCEXCFILE"'"
     INCLUDE=$INCLUDE$TMP
   fi


### PR DESCRIPTION
The if condition was not quoted correctly, leading to an error that a unary
operator is expected. This fixes it by quoting the condition correctly, which
is already done in the same way for most of the following if conditions.
