### PR TITLE
add support for DragonFly and OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Be sure to make the script executable (`chmod +x`) before you hit the gas.
 ## Requirements
 
 * [duplicity](http://duplicity.nongnu.org/)
-* Basic utilities like: [which](http://unixhelp.ed.ac.uk/CGI/man-cgi?which) and [tee](http://linux.die.net/man/1/tee) (should already be available on most Linux systems)
+* Basic utilities like: [bash](https://www.gnu.org/software/bash/), [which](http://unixhelp.ed.ac.uk/CGI/man-cgi?which) and [tee](http://linux.die.net/man/1/tee) (should already be available on most Linux systems)
 * [gpg](http://www.gnupg.org/) *`optional`*
 * [Amazon S3](http://aws.amazon.com/s3/) *`optional`*
 * [s3cmd](http://s3tools.org/s3cmd) *`optional`*


### PR DESCRIPTION
DragonFly is a FreeBSD derivative, so the same `du` flags as for FreeBSD
and Darwin apply. OpenBSD does not support exclusion.

The correct invocation for in-place `sed` without backup varies. GNU Sed
allows just leaving out the suffix, but BSD Sed requires an empty suffix
(which in turn GNU Sed doesn't accept). OpenBSD Sed has no in-place
option, use `ed` instead.

`mail` works the same on all BSD.

Explicitly list `bash` dependency, it's not installed on most BSD by default.
