### PR TITLE
Add a note in configuration about escaping "$" in passphrase

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -65,6 +65,7 @@ ENCRYPTION='yes'
 # (your backups will be encrypted with this password) or is used
 # for the "GPG_SIGN_KEY" (see below).
 # Comment out if you aren't using encryption
+# Note: if you have a '$' in your passphrase, escape it with a '\'
 PASSPHRASE="foobar_gpg_passphrase"
 
 # Specify which GPG keys you would like to use (even if you have only one).


### PR DESCRIPTION
Might be useful for someone as for me it took a bit to notice my random passphrase contained a dollar sign
