### PR TITLE
fix: ensure a trailing slash in log dir name

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -177,6 +177,9 @@ if [[ -n "$FTP_PASSWORD" ]]; then
   export FTP_PASSWORD
 fi
 
+# Ensure a trailing slash always exists in the log directory name
+LOGDIR="${LOGDIR%/}/"
+
 LOGFILE="${LOGDIR}${LOG_FILE}"
 DUPLICITY="$(which duplicity)"
 


### PR DESCRIPTION
LOGDIR="/foo/bar" (without  a trailing slash) produces /foo/barbackup.lock and/foo/barduplicity-\* files, not /foo/bar/backup.lock and /foo/bar/duplicity-\* files as expected. This fix ensures a trailing slash in the log dir name.
