### PR TITLE
Collection status over ssh

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -269,3 +269,7 @@ MAIL="mailx"     # default command for Linux mail
 # printed to the logfile.  This way, you can see if the problem is with the
 # script or with duplicity.
 #ECHO=$(which echo)
+
+
+# Set the temporary directory for duplicity to use.
+#TMPDIR="/tmp"

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -177,6 +177,10 @@ if [[ -n "$FTP_PASSWORD" ]]; then
   export FTP_PASSWORD
 fi
 
+if [[ -n "$TMPDIR" ]]; then
+  export TMPDIR
+fi
+
 # Ensure a trailing slash always exists in the log directory name
 LOGDIR="${LOGDIR%/}/"
 


### PR DESCRIPTION
Having ssh options set to something like:

STATIC_OPTIONS="--ssh-options='-oProtocol=2 -oIdentityFile=/path/to/file'"

causes an error when doing a collection status or list files:

duplicity: error: no such option: -o

Also added an option to allow overriding of the TMPDIR variable which duplicity uses.
