### PR TITLE
Collection status over ssh

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -702,6 +702,7 @@ case "$COMMAND" in
       STATIC_OPTIONS="$STATIC_OPTIONS --time $TIME"
     fi
 
+    eval \
     ${DUPLICITY} ${OPTION} ${VERBOSITY} ${STATIC_OPTIONS} \
     $ENCRYPT \
     ${DEST} | tee -a ${LOGFILE}
@@ -710,6 +711,8 @@ case "$COMMAND" in
 
   "collection-status")
     OPTION="collection-status"
+
+    eval \
     ${DUPLICITY} ${OPTION} ${VERBOSITY} ${STATIC_OPTIONS} \
     $ENCRYPT \
     ${DEST} | tee -a ${LOGFILE}


### PR DESCRIPTION
Doing a collection status or file list with ssh options enabled, like:

STATIC_OPTIONS="--ssh-options='-oProtocol=2 -oIdentityFile=/path/to/file'"
causes an error:

"duplicity: error: no such option: -o"
