### PR TITLE
When creating our log directory we should set its owner:group to that of the log file owner

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -233,13 +233,16 @@ CLEAN_UP_VARIABLE="4"
 #REMOVE_INCREMENTALS_OLDER_THAN="4"
 
 # LOGFILE INFORMATION DIRECTORY
-# Provide directory for logfile, ownership of logfile, and verbosity level.
+# Provide directory for logfile, ownership of logfile & directory, and verbosity level.
 # I run this script as root, but save the log files under my user name --
 # just makes it easier for me to read them and delete them as needed.
 
 LOGDIR="/home/foobar_user_name/logs/test2/"
 LOG_FILE="duplicity-`date +%Y-%m-%d_%H-%M`.txt"
 LOG_FILE_OWNER="foobar_user_name:foobar_user_name"
+# Note that if the configured LOGDIR does not exist it will be created
+# and its owner:group set to that of the configured LOG_FILE_OWNER.
+# If the configured LOGDIR already exists no change to owner:group is attempted.
 #REMOVE_LOGS_OLDER_THAN='30' # (days) uncomment to activate
 VERBOSITY="-v3"
 

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -281,6 +281,14 @@ check_logdir()
     else
       echo "Directory ${LOGDIR} successfully created."
     fi
+    echo "Attempting to change owner:group of ${LOGDIR} to ${LOG_FILE_OWNER} ..."
+    if ! chown ${LOG_FILE_OWNER} ${LOGDIR}; then
+      echo "User ${USER} could not change the owner:group of ${LOGDIR} to $LOG_FILE_OWNER"
+      echo "Aborting..."
+      exit 1
+    else
+      echo "Directory ${LOGDIR} successfully changed to owner:group of ${LOG_FILE_OWNER}"
+    fi
   elif [ ! -w ${LOGDIR} ]; then
     echo "Log directory ${LOGDIR} is not writeable by this user: ${USER}"
     echo "Aborting..."


### PR DESCRIPTION
Given that duplicity-backup will auto create the log directory when it doesn't already exist it makes sense, at least to me, that we create this log directory with the same owner:group as configured for log file owner.  This directly addresses the issue of having logs in ones home directory that originate from a root cron job.  Duplicity-backup as is would create a root:root owned directory in a normal users home which seems inappropriate and can cause problems with non root backups/restores of that users home directory.