### PR TITLE
Source disk use report was missing if INCLIST was un-configured, it also included excluded dirs

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -348,7 +348,7 @@ get_lock()
 
 get_source_file_size()
 {
-  echo "---------[ Source File Size Information ]---------" >> ${LOGFILE}
+  echo "-----------[ Source Disk Use Information ]-----------" >> ${LOGFILE}
 
   # Patches to support spaces in paths-
   # Remove space as a field separator temporarily
@@ -397,7 +397,7 @@ get_source_file_size()
 
 get_remote_file_size()
 {
-  echo "------[ Destination File Size Information ]------" >> ${LOGFILE}
+  echo "---------[ Destination Disk Use Information ]--------" >> ${LOGFILE}
 
   dest_type=`echo ${DEST} | cut -c 1,2`
   case $dest_type in
@@ -423,7 +423,7 @@ get_remote_file_size()
     ;;
   esac
 
-  echo "Current Remote Backup File Size: ${SIZE}" >> ${LOGFILE}
+  echo "Current Remote Backup Disk Usage: ${SIZE}" >> ${LOGFILE}
   echo >> ${LOGFILE}
 }
 
@@ -472,7 +472,7 @@ include_exclude()
 
 duplicity_cleanup()
 {
-  echo "-----------[ Duplicity Cleanup ]-----------" >> ${LOGFILE}
+  echo "----------------[ Duplicity Cleanup ]----------------" >> ${LOGFILE}
   if [[ "${CLEAN_UP_TYPE}" != "none" && ! -z ${CLEAN_UP_TYPE} && ! -z ${CLEAN_UP_VARIABLE} ]]; then
     eval ${ECHO} ${DUPLICITY} ${CLEAN_UP_TYPE} ${CLEAN_UP_VARIABLE} ${STATIC_OPTIONS} --force \
       ${ENCRYPT} \
@@ -703,7 +703,7 @@ case "$COMMAND" in
     read ANSWER
     if [ "$ANSWER" != "yes" ]; then
       echo "You said << ${ANSWER} >> so I am exiting now."
-      echo -e "--------    END    --------\n" >> ${LOGFILE}
+      echo -e "---------------------    END    ---------------------\n" >> ${LOGFILE}
       exit 1
     fi
 
@@ -728,7 +728,7 @@ case "$COMMAND" in
     ${DUPLICITY} ${OPTION} ${VERBOSITY} ${STATIC_OPTIONS} \
     $ENCRYPT \
     ${DEST} | tee -a ${LOGFILE}
-    echo -e "--------    END    --------\n" >> ${LOGFILE}
+    echo -e "---------------------    END    ---------------------\n" >> ${LOGFILE}
   ;;
 
   "collection-status")
@@ -738,7 +738,7 @@ case "$COMMAND" in
     ${DUPLICITY} ${OPTION} ${VERBOSITY} ${STATIC_OPTIONS} \
     $ENCRYPT \
     ${DEST} | tee -a ${LOGFILE}
-    echo -e "--------    END    --------\n" >> ${LOGFILE}
+    echo -e "---------------------    END    ---------------------\n" >> ${LOGFILE}
   ;;
 
   "backup")
@@ -754,7 +754,7 @@ case "$COMMAND" in
   ;;
 esac
 
-echo -e "--------    END DUPLICITY-BACKUP SCRIPT    --------\n" >> ${LOGFILE}
+echo -e "---------    END DUPLICITY-BACKUP SCRIPT    ---------\n" >> ${LOGFILE}
 
 email_logfile
 

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -366,19 +366,29 @@ get_source_file_size()
    *)
     DUEXCFLAG="--exclude-from=-"
     ;;
-esac
+  esac
 
   for exclude in ${EXCLIST[@]}; do
     DUEXCLIST="${DUEXCLIST}${exclude}\n"
   done
 
-  for include in ${INCLIST[@]}
-    do
-      echo -e '"'$DUEXCLIST'"' | \
-      du -hs ${DUEXCFLAG} ${include} | \
-      awk '{ FS="\t"; $0=$0; print $1"\t"$2 }' \
-      >> ${LOGFILE}
-  done
+  # if $INCLIST non zero then itterate through it for df readings, else just df $ROOT
+  # in both cases consider the excluded directories
+  if [ ! -z "$INCLIST" ]; then
+    for include in ${INCLIST[@]}
+      do
+        echo -e '"'$DUEXCLIST'"' | \
+        du -hs ${DUEXCFLAG} ${include} | \
+        awk '{ FS="\t"; $0=$0; print $1"\t"$2 }' \
+        >> ${LOGFILE}
+      done
+  else
+    echo -e '"'$DUEXCLIST'"' | \
+    du -hs ${DUEXCFLAG} $ROOT | \
+    awk '{ FS="\t"; $0=$0; print $1"\t"$2 }' \
+    >> ${LOGFILE}
+  fi
+  
   echo >> ${LOGFILE}
 
   # Restore IFS

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -372,7 +372,7 @@ get_source_file_size()
     DUEXCLIST="${DUEXCLIST}${exclude}\n"
   done
 
-  # if $INCLIST non zero then itterate through it for df readings, else just df $ROOT
+  # if $INCLIST non zero then itterate through it for du -hs readings, else just du -hs $ROOT
   # in both cases consider the excluded directories
   if [ ! -z "$INCLIST" ]; then
     for include in ${INCLIST[@]}

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -377,13 +377,13 @@ get_source_file_size()
   if [ ! -z "$INCLIST" ]; then
     for include in ${INCLIST[@]}
       do
-        echo -e '"'$DUEXCLIST'"' | \
+        echo -e "$DUEXCLIST" | \
         du -hs ${DUEXCFLAG} ${include} | \
         awk '{ FS="\t"; $0=$0; print $1"\t"$2 }' \
         >> ${LOGFILE}
       done
   else
-    echo -e '"'$DUEXCLIST'"' | \
+    echo -e "$DUEXCLIST" | \
     du -hs ${DUEXCFLAG} $ROOT | \
     awk '{ FS="\t"; $0=$0; print $1"\t"$2 }' \
     >> ${LOGFILE}


### PR DESCRIPTION
When duplicity-backup.sh was run with INCLIST remarked out, ie just using ROOT, the source disk usage report would not be generated. These reports also failed to exclude disk usage of those directories detailed in EXCLIST, within the limits of du anyway. Also du reports the on disk space usage not the file size so I have changed all relevant (hopefully) user facing reports to that end.  Plus a little trivial log file header output width format cleanup.
Hope this helps.