### PR TITLE
Remove not on -z INCLIST check, and copy whole array

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -376,7 +376,7 @@ get_source_file_size()
   if [ -z "$INCLIST" ]; then
     DUINCLIST=($ROOT)
   else
-    DUINCLIST=$INCLIST
+    DUINCLIST=("${INCLIST[@]}")
   fi
 
   for include in ${DUINCLIST[@]}; do

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -373,7 +373,7 @@ get_source_file_size()
   done
 
   # if INCLIST is not set or empty, add ROOT to it to be able to calculate disk usage
-  if [ ! -z "$INCLIST" ]; then
+  if [ -z "$INCLIST" ]; then
     DUINCLIST=($ROOT)
   else
     DUINCLIST=$INCLIST


### PR DESCRIPTION
With these modifications I find that the re-factored code works for me, ie when INCLIST is undefined I get a correct du -sh of ROOT and when it is defined with either 1 2 or 3 elements they are individually reported as disk use lines in the Source Disk Use Information section of the log.  I prefer your re-factored version as its more DRY (Don't Repeat Yourself) than my original.  Also clearer to have both a DUEXCLIST and a DUINCLIST.