### PR TITLE
unset ftp_password variable

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -770,5 +770,6 @@ unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
 unset PASSPHRASE
 unset SIGN_PASSPHRASE
+unset FTP_PASSWORD
 
 # vim: set tabstop=2 shiftwidth=2 sts=2 autoindent smartindent:


### PR DESCRIPTION
Simple but important security wise I think.  But should we also unset the GPG variables?