### PR TITLE
Improve reporting on s3cmd state and make disk use log report formats consistent, and add type to destination report

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -212,7 +212,7 @@ elif [ "$ENCRYPTION" = "no" ]; then
   ENCRYPT="--no-encryption"
 fi
 
-NO_S3CMD="WARNING: s3cmd is not installed, remote file \
+NO_S3CMD="WARNING: s3cmd no found in PATH, remote file \
 size information unavailable."
 NO_S3CMD_CFG="WARNING: s3cmd is not configured, run 's3cmd --configure' \
 in order to retrieve remote file size information. Remote file \
@@ -418,7 +418,7 @@ get_remote_file_size()
           if ! $S3CMD_CONF_FOUND ; then
               SIZE="s3cmd config not found"
           else
-              SIZE="s3cmd not installed"
+              SIZE="s3cmd not found in PATH"
           fi
       fi
     ;;

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -398,14 +398,16 @@ get_source_file_size()
 get_remote_file_size()
 {
   echo "---------[ Destination Disk Use Information ]--------" >> ${LOGFILE}
-
+  FRIENDLY_TYPE_NAME=""
   dest_type=`echo ${DEST} | cut -c 1,2`
   case $dest_type in
     "fi")
+      FRIENDLY_TYPE_NAME="File"
       TMPDEST=`echo ${DEST} | cut -c 6-`
       SIZE=`du -hs ${TMPDEST} | awk '{print $1}'`
     ;;
     "s3")
+      FRIENDLY_TYPE_NAME="S3"
       if $S3CMD_AVAIL ; then
           TMPDEST=$(echo ${DEST} | cut -c 11-)
           dest_scheme=$(echo ${DEST} | cut -f -1 -d :)
@@ -416,18 +418,20 @@ get_remote_file_size()
           SIZE=`${S3CMD} du -H s3://${TMPDEST} | awk '{print $1}'`
       else
           if ! $S3CMD_CONF_FOUND ; then
-              SIZE="s3cmd config not found"
+              SIZE="-s3cmd config not found-"
           else
-              SIZE="s3cmd not found in PATH"
+              SIZE="-s3cmd not found in PATH-"
           fi
       fi
     ;;
     *)
-      SIZE="unsupported by backend"
+      # cover all so just grab first 4 chars from DEST
+      FRIENDLY_TYPE_NAME=`echo ${DEST} | cut -c 1,4`
+      SIZE="unsupported on"
     ;;
   esac
 
-  echo "Current Remote Backup Disk Usage: ${SIZE}" >> ${LOGFILE}
+  echo -e ""$SIZE"\t"$FRIENDLY_TYPE_NAME" type backend" >> ${LOGFILE}
   echo >> ${LOGFILE}
 }
 

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -230,15 +230,18 @@ if  [ "`echo ${DEST} | cut -c 1,2`" = "s3" ]; then
   if [ ! -x "$S3CMD" ]; then
     echo $NO_S3CMD; S3CMD_AVAIL=false
   elif [ -z "$S3CMD_CONF_FILE" -a ! -f "${HOME}/.s3cfg" ]; then
+    S3CMD_CONF_FOUND=false
     echo $NO_S3CMD_CFG; S3CMD_AVAIL=false
   elif [ ! -z "$S3CMD_CONF_FILE" -a ! -f "$S3CMD_CONF_FILE" ]; then
+    S3CMD_CONF_FOUND=false
     echo "${S3CMD_CONF_FILE} not found, check S3CMD_CONF_FILE variable in duplicity-backup's configuration!";
     echo $NO_S3CMD_CFG;
     S3CMD_AVAIL=false
-  else
+  else    
     S3CMD_AVAIL=true
-
+    S3CMD_CONF_FOUND=true
     if [ ! -z "$S3CMD_CONF_FILE" -a -f "$S3CMD_CONF_FILE" ]; then
+      # if conf file specified and it exists then add it to the command line for s3cmd
       S3CMD="${S3CMD} -c ${S3CMD_CONF_FILE}"
     fi
   fi
@@ -412,7 +415,11 @@ get_remote_file_size()
           fi
           SIZE=`${S3CMD} du -H s3://${TMPDEST} | awk '{print $1}'`
       else
-          SIZE="s3cmd not installed."
+          if ! $S3CMD_CONF_FOUND ; then
+              SIZE="s3cmd config not found"
+          else
+              SIZE="s3cmd not installed"
+          fi
       fi
     ;;
     *)


### PR DESCRIPTION
Change reporting of s3cmd 'not installed' to 'not in PATH' as less misleading when s3cmd installed from source where it defaults to /usr/local/bin which is typically not in root cronjob path environment.  This way we point users to the PATH issue.  Also added ability to report s3cmd config not found in destination report.  Changed destination disk use report to be consistent with source disk use report as cleaner / quicker to scan and removed redundancy in wording so now more brief.  Added a destination type to this destination disk use information report. Tested successfully on file and s3 type destinations; and where s3cmd was not in PATH with and without config and with s3cmd in PATH with and without config.
Hope this helps; I found it useful especially where s3cmd was concerned.