### PR TITLE
- added EMAIL_FAILURE_ONLY option to send e-mails only if there was a…

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -77,6 +77,10 @@
 #
 ROOT="/home"
 
+# Set hostname for this duplicity instance, usefull for e-mail reports
+#
+HOSTNAME=$(hostname -f)
+
 # ------------------------------------------------------------------------------
 # BACKUP DESTINATION INFORMATION
 # ------------------------------------------------------------------------------
@@ -371,6 +375,7 @@ VERBOSITY="-v3"
 EMAIL_TO=
 EMAIL_FROM=
 EMAIL_SUBJECT=
+EMAIL_FAILURE_ONLY="yes" # send e-mail only if there was an error while creating backup
 
 # command to use to send mail
 MAIL="mailx"     # default command for Linux mail

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -556,6 +556,7 @@ duplicity_cleanup()
 
 duplicity_backup()
 {
+{
   eval ${ECHO} ${DUPLICITY} ${OPTION} ${VERBOSITY} ${STATIC_OPTIONS} \
   ${ENCRYPT} \
   ${EXCLUDE} \
@@ -563,6 +564,9 @@ duplicity_backup()
   ${EXCLUDEROOT} \
   ${ROOT} ${DEST} \
   >> ${LOGFILE}
+} || {
+  BACKUP_ERROR=1
+}
 }
 
 setup_passphrase()
@@ -680,7 +684,7 @@ backup_this_script()
 check_variables
 check_logdir
 
-echo -e "--------    START DUPLICITY-BACKUP SCRIPT    --------\n" >> ${LOGFILE}
+echo -e "--------    START DUPLICITY-BACKUP SCRIPT for ${HOSTNAME}   --------\n" >> ${LOGFILE}
 
 get_lock
 
@@ -832,7 +836,20 @@ esac
 
 echo -e "---------    END DUPLICITY-BACKUP SCRIPT    ---------\n" >> ${LOGFILE}
 
-email_logfile
+if [ ${EMAIL_FAILURE_ONLY} == "yes" ]
+then
+	if [ ${BACKUP_ERROR} ]; then
+		EMAIL_SUBJECT="BACKUP ERROR: ${EMAIL_SUBJECT}"
+		email_logfile
+	fi
+else
+	if [ ${BACKUP_ERROR} ]; then
+		EMAIL_SUBJECT="BACKUP ERROR: ${EMAIL_SUBJECT}"
+	else
+		EMAIL_SUBJECT="BACKUP OK: ${EMAIL_SUBJECT}"
+	fi
+		email_logfile
+fi
 
 # remove old logfiles
 # stops them from piling up infinitely


### PR DESCRIPTION
…n error while doing backup (claring wishlist) - thanks to Adam Buhl for help with this
- added HOSTNAME option to inform in e-mail report for which server is this report for
- e-mail subject is rewrited now to know if backup was OK or not