### PR TITLE
Support mailx from mailutils

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -383,7 +383,7 @@ email_logfile()
               mailcmd_msmtp;;
             mail|mailx)
               case ${MAILCMD_BASENAME} in
-                bsd-mailx)
+                bsd-mailx|mail.mailutils)
                   mailcmd_bsd_mailx;;
                 heirloom-mailx)
                   mailcmd_heirloom_mailx;;


### PR DESCRIPTION
Mail command in debian provided by mailutils packages give "MAILCMD_BASENAME=mail.mailutils" which results to the mailcmd_else method instead of mailcmd_bsd_mailx. This commit fix that. 