### PR TITLE
use tee for logging to logfile and stdout

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -641,6 +641,7 @@ duplicity_cleanup_failed()
   {
     eval "${ECHO}" "${DUPLICITY}" "${OPTION}" "${VERBOSITY}" "${STATIC_OPTIONS}" \
     "${DEST}" \
+    "${ENCRYPT}" \
      | tee -a "${LOGFILE}"
   } || {
     BACKUP_ERROR=1


### PR DESCRIPTION
I need both, logfile and stdout, to see whats happening while the backup is running. Thus, I use tee to copy stdout into a file. Don't know if this is always useful. Maybe we can make this optional?

Furthermore, the duplicity_cleanup_failed() method did not not work for unencrypted backups.