### PR TITLE
Add IFTTT notification service

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -408,7 +408,7 @@ MAIL="mailx"     # default command for Linux mail
 # Third-party notification services. If NOTIFICATION_SERVICE is not provided, no
 # notifications will be sent.
 
-# Possible values for NOTIFICATION_SERVICE are: slack, pushover
+# Possible values for NOTIFICATION_SERVICE are: slack, pushover, ifttt
 NOTIFICATION_SERVICE=""
 NOTIFICATION_FAILURE_ONLY="yes" # send notifications only if there was an error while creating backup
 
@@ -422,6 +422,11 @@ SLACK_EMOJI="package"
 PUSHOVER_TOKEN="" # App token generated at pushover.net
 PUSHOVER_USER="" # User key from pushover.net
 
+# Provider: IFTTT
+IFTTT_KEY="" # Key for MAKER channel at IFTTT
+IFTTT_MAKER_EVENT="duplicity" # name the event to trigger at IFTTT Maker Channel
+IFTTT_HOOK_URL="https://maker.ifttt.com/trigger/$IFTTT_MAKER_EVENT/with/key/$IFTTT_KEY" # ONLY change this if IFTTT changes it
+IFTTT_VALUE2="" # general purpose value to pass to your maker channel (optional)
 
 # ------------------------------------------------------------------------------
 # TROUBLESHOOTING

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -417,7 +417,7 @@ send_notification()
       curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"${NOTIFICATION_CONTENT}\", \"channel\": \"${SLACK_CHANNEL}\", \"username\": \"${SLACK_USERNAME}\", \"icon_emoji\": \":${SLACK_EMOJI}:\"}" "${SLACK_HOOK_URL}"
       echo -e "Slack notification sent to channel ${SLACK_CHANNEL}" >> "${LOGFILE}"
     elif [ "${NOTIFICATION_SERVICE}" = "ifttt" ]; then
-    	curl -X POST -H 'Content-type: application/json' --data "{\"value1\": \"${NOTIFICATION_CONTENT}\", \"value2\": \"${IFTTT_VALUE2}\"}" "${IFTTT_HOOK_URL}"
+      curl -X POST -H 'Content-type: application/json' --data "{\"value1\": \"${NOTIFICATION_CONTENT}\", \"value2\": \"${IFTTT_VALUE2}\"}" "${IFTTT_HOOK_URL}"
       echo -e "IFTTT notification sent to Maker channel event ${IFTTT_EVENT}" >> "${LOGFILE}"	
     elif [ "${NOTIFICATION_SERVICE}" = "pushover" ]; then
       curl -s \

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -416,6 +416,9 @@ send_notification()
     if [ "${NOTIFICATION_SERVICE}" = "slack" ]; then
       curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"${NOTIFICATION_CONTENT}\", \"channel\": \"${SLACK_CHANNEL}\", \"username\": \"${SLACK_USERNAME}\", \"icon_emoji\": \":${SLACK_EMOJI}:\"}" "${SLACK_HOOK_URL}"
       echo -e "Slack notification sent to channel ${SLACK_CHANNEL}" >> "${LOGFILE}"
+    elif [ "${NOTIFICATION_SERVICE}" = "ifttt" ]; then
+    	curl -X POST -H 'Content-type: application/json' --data "{\"value1\": \"${NOTIFICATION_CONTENT}\", \"value2\": \"${IFTTT_VALUE2}\"}" "${IFTTT_HOOK_URL}"
+      echo -e "IFTTT notification sent to Maker channel event ${IFTTT_EVENT}" >> "${LOGFILE}"	
     elif [ "${NOTIFICATION_SERVICE}" = "pushover" ]; then
       curl -s \
       -F "token=${PUSHOVER_TOKEN}" \


### PR DESCRIPTION
Add the ability to trigger a custom event on the Maker channel provided
by IFTTT service. With this trigger one can program actions on another
channels. Examples:

- Log backup notification to a google spreadsheet;
- Receive notification on devices with IFTTT application installed;
- Send e-mails
- Log to evernote
- Turn a Philips Hue light green for good backup or red on errors

IFTTT Maker channel accepts three values (named `value1`, `value2`, `value3`)
as part of the trigger. This implementation sends the content of
`NOTIFICATION_CONTENT` as `value1` parameter and let `value2` be defined at
configuration file. At this time `value3` is not used.